### PR TITLE
Improved SCP activation error handling, and some typo fixes.

### DIFF
--- a/XboxKeyboardMouse/XboxController/Emulation/Activate.cs
+++ b/XboxKeyboardMouse/XboxController/Emulation/Activate.cs
@@ -18,8 +18,10 @@ namespace XboxKeyboardMouse {
             try {
                 scpbus = new ScpBus();
             } catch (Exception ex) {
-                MessageBox.Show("SCP Bus failed to initialize");
-                MessageBox.Show(ex.ToString());
+                MessageBox.Show("You probably need to run the ScpToolkit Driver Installer." +
+                                System.Environment.NewLine + System.Environment.NewLine + ex.ToString(),
+                                "SCP Bus failed to initialize");
+                Environment.Exit(-1);
             }
 
             scpbus.PlugIn(1);

--- a/XboxKeyboardMouse/XboxController/SCP/ScpBus.cs
+++ b/XboxKeyboardMouse/XboxController/SCP/ScpBus.cs
@@ -2,7 +2,7 @@
  * ScpDriverInterface - by Mogzol (and of course Scarlet.Crush) - Jan, 2016
  *
  * This is a simple little DLL which allows you to use Scarlet.Crush's SCP Virtual
- * Bus Driver to emulate XBox 360 Controllers.
+ * Bus Driver to emulate Xbox 360 Controllers.
  * 
  * Most of the code here has been ripped out of his ScpControl source code, mostly
  * from the ScpDevice and BusDevice classes, so obviously credit and major props to
@@ -22,7 +22,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace ScpDriverInterface {
     /// <summary>
-    /// Emulates XBox 360 controllers via Scarlet.Crush's SCP Virtual Bus Driver.
+    /// Emulates Xbox 360 controllers via Scarlet.Crush's SCP Virtual Bus Driver.
     /// </summary>
     public class ScpBus : IDisposable {
         private const string SCP_BUS_CLASS_GUID = "{F679F562-3164-42CE-A4DB-E7DDBE723909}";
@@ -81,7 +81,7 @@ namespace ScpDriverInterface {
         }
 
         /// <summary>
-        /// Plugs in an emulated XBox 360 controller.
+        /// Plugs in an emulated Xbox 360 controller.
         /// </summary>
         /// <param name="controllerNumber">Used to identify the controller. Give each controller you plug in a different number. Number must be non-zero.</param>
         /// <returns>True if the operation was successful, false otherwise.</returns>
@@ -106,7 +106,7 @@ namespace ScpDriverInterface {
         }
 
         /// <summary>
-        /// Unplugs an emulated XBox 360 controller.
+        /// Unplugs an emulated Xbox 360 controller.
         /// </summary>
         /// <param name="controllerNumber">The controller you want to unplug.</param>
         /// <returns>True if the operation was successful, false otherwise.</returns>
@@ -131,7 +131,7 @@ namespace ScpDriverInterface {
         }
 
         /// <summary>
-        /// Unplugs all emulated XBox 360 controllers.
+        /// Unplugs all emulated Xbox 360 controllers.
         /// </summary>
         /// <returns>True if the operation was successful, false otherwise.</returns>
         public bool UnplugAll() {
@@ -150,7 +150,7 @@ namespace ScpDriverInterface {
         }
 
         /// <summary>
-        /// Sends an input report for the current state of the specified emulated XBox 360 controller. Note: Only use this if you don't care about rumble data, otherwise use the 3-parameter version of Report().
+        /// Sends an input report for the current state of the specified emulated Xbox 360 controller. Note: Only use this if you don't care about rumble data, otherwise use the 3-parameter version of Report().
         /// </summary>
         /// <param name="controllerNumber">The controller to report.</param>
         /// <param name="controllerReport">The controller report. If using the included X360Controller class, this can be generated with the GetReport() method. Otherwise see http://free60.org/wiki/GamePad#Input_report for details.</param>
@@ -160,7 +160,7 @@ namespace ScpDriverInterface {
         }
 
         /// <summary>
-        /// Sends an input report for the current state of the specified emulated XBox 360 controller. If you care about rumble data, make sure you check the output report for rumble data every time you call this.
+        /// Sends an input report for the current state of the specified emulated Xbox 360 controller. If you care about rumble data, make sure you check the output report for rumble data every time you call this.
         /// </summary>
         /// <param name="controllerNumber">The controller to report.</param>
         /// <param name="controllerReport">The controller report. If using the included X360Controller class, this can be generated with the GetReport() method. Otherwise see http://free60.org/wiki/GamePad#Input_report for details.</param>

--- a/XboxKeyboardMouse/XboxController/SCP/X360Controller.cs
+++ b/XboxKeyboardMouse/XboxController/SCP/X360Controller.cs
@@ -2,7 +2,7 @@
 
 namespace ScpDriverInterface {
     /// <summary>
-    /// A virtual XBox 360 Controller. After setting the desired values, use the GetReport() method to generate a controller report that can be used with ScpBus's Report() method.
+    /// A virtual Xbox 360 Controller. After setting the desired values, use the GetReport() method to generate a controller report that can be used with ScpBus's Report() method.
     /// </summary>
     public class X360Controller {
         /// <summary>
@@ -88,9 +88,9 @@ namespace ScpDriverInterface {
         public short RightStickY { get; set; }
 
         /// <summary>
-        /// Generates a XBox 360 controller report as specified here: http://free60.org/wiki/GamePad#Input_report. This can be used with ScpBus's Report() method.
+        /// Generates a Xbox 360 controller report as specified here: http://free60.org/wiki/GamePad#Input_report. This can be used with ScpBus's Report() method.
         /// </summary>
-        /// <returns>A 20-byte XBox 360 controller report.</returns>
+        /// <returns>A 20-byte Xbox 360 controller report.</returns>
         public byte[] GetReport() {
             byte[] bytes = new byte[20];
 


### PR DESCRIPTION
* Shows a single MessageBox instead of two, with combined messaging.
* Adds a helpful user suggestion that should solve this error for most people.
* Exits cleanly (non-zero) afterwards, since the error is not recoverable.
* Fix "XBox" capitalization typos.